### PR TITLE
State example

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,7 @@
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
-  max-width: 500px;
+  width: 400px;
 }
 
 .card {

--- a/src/App.css
+++ b/src/App.css
@@ -3,6 +3,7 @@
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
+  max-width: 500px;
 }
 
 .card {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,19 +4,23 @@ import Routines from "./components/Routines";
 import Start from "./components/Start";
 import ViewState, {ChangeViewState} from "./ViewState";
 import data from './data.json';
+import Routine from "./components/Routine";
 
 function App() {
   const [currentView, setCurrentView] = useState(ViewState.Home);
+  const [routineName, setRoutineName] = useState("");
 
   const handleOnClick = (newView: ChangeViewState) => {
-    console.log('Handled')
+    console.log('Handled ', newView.name)
     setCurrentView(newView.to);
+    if(newView.name){setRoutineName(newView.name)};
   };
 
   return (
     <>
       {currentView === ViewState.Home ? <Start onStartClick={handleOnClick} /> : null}
-      {currentView === ViewState.Routines ? <Routines routines={data.routines} onBackClick={handleOnClick} /> : null}
+      {currentView === ViewState.Routines ? <Routines routines={data.routines} onShowRoutineClick={handleOnClick} onBackClick={handleOnClick} /> : null}
+      {currentView === ViewState.Routine ? <Routine name={routineName} /> : null}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import "./App.css";
 import Routines from "./components/Routines";
-import Start from "./components/Start";
+import Motivational from "./components/Motivational";
 import ViewState, {ChangeViewState} from "./ViewState";
 import data from './data.json';
 import Routine from "./components/Routine";
@@ -18,7 +18,7 @@ function App() {
 
   return (
     <>
-      {currentView === ViewState.Home ? <Start onStartClick={handleOnClick} /> : null}
+      {currentView === ViewState.Home ? <Motivational onMotivationalClick={handleOnClick} /> : null}
       {currentView === ViewState.Routines ? <Routines routines={data.routines} onShowRoutineClick={handleOnClick} onBackClick={handleOnClick} /> : null}
       {currentView === ViewState.Routine ? <Routine name={routineName} /> : null}
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,11 @@ import "./App.css";
 import Routines from "./components/Routines";
 import Start from "./components/Start";
 import ViewState, {ChangeViewState} from "./ViewState";
+import data from './data.json';
 
 function App() {
   const [currentView, setCurrentView] = useState(ViewState.Home);
-  
+
   const handleOnClick = (newView: ChangeViewState) => {
     console.log('Handled')
     setCurrentView(newView.to);
@@ -15,7 +16,7 @@ function App() {
   return (
     <>
       {currentView === ViewState.Home ? <Start onStartClick={handleOnClick} /> : null}
-      {currentView === ViewState.Routines ? <Routines onBackClick={handleOnClick} /> : null}
+      {currentView === ViewState.Routines ? <Routines routines={data.routines} onBackClick={handleOnClick} /> : null}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,20 @@
+import { useState } from "react";
 import "./App.css";
-import Button from "./components/Button";
+import Routines from "./components/Routines";
+import Start from "./components/Start";
+import ViewState, {ChangeViewState} from "./ViewState";
 
 function App() {
-  const handleOnClick = () => {
-    console.log("Clicked!");
+  const [currentView, setCurrentView] = useState(ViewState.Home);
+  const handleOnClick = (newView: ChangeViewState) => {
+    console.log('Handled')
+    setCurrentView(newView.to);
   };
 
   return (
     <>
-      <h1>Routines</h1>
-      <p>
-        Embracing routines empowers you to craft a path towards success,
-        enabling consistent progress, building discipline, and unlocking your
-        fullest potential every single day.
-      </p>
-      <Button onClick={handleOnClick}>Let's go!</Button>
+      {currentView === ViewState.Home ? <Start onStartClick={handleOnClick} /> : null}
+      {currentView === ViewState.Routines ? <Routines /> : null}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import ViewState, {ChangeViewState} from "./ViewState";
 
 function App() {
   const [currentView, setCurrentView] = useState(ViewState.Home);
+  
   const handleOnClick = (newView: ChangeViewState) => {
     console.log('Handled')
     setCurrentView(newView.to);
@@ -14,7 +15,7 @@ function App() {
   return (
     <>
       {currentView === ViewState.Home ? <Start onStartClick={handleOnClick} /> : null}
-      {currentView === ViewState.Routines ? <Routines /> : null}
+      {currentView === ViewState.Routines ? <Routines onBackClick={handleOnClick} /> : null}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,20 @@
-import { useState } from "react";
 import "./App.css";
+import Button from "./components/Button";
 
 function App() {
-  const [count, setCount] = useState(0);
+  const handleOnClick = () => {
+    console.log("Clicked!");
+  };
 
   return (
     <>
       <h1>Routines</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-      </div>
+      <p>
+        Embracing routines empowers you to craft a path towards success,
+        enabling consistent progress, building discipline, and unlocking your
+        fullest potential every single day.
+      </p>
+      <Button onClick={handleOnClick}>Let's go!</Button>
     </>
   );
 }

--- a/src/ViewState.ts
+++ b/src/ViewState.ts
@@ -1,10 +1,12 @@
 enum ViewState {
-    Home = 1,
-    Routines = 2
+    Home,
+    Routines,
+    Routine
 }
 
 export interface ChangeViewState {
-    to: ViewState
+    to: ViewState,
+    name?: string
 }
 
 export default ViewState;

--- a/src/ViewState.ts
+++ b/src/ViewState.ts
@@ -1,0 +1,10 @@
+enum ViewState {
+    Home = 1,
+    Routines = 2
+}
+
+export interface ChangeViewState {
+    to: ViewState
+}
+
+export default ViewState;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,16 @@
+import styles from "../styles/Button.module.css";
+
+interface ButtonProps {
+  children: string;
+  onClick: () => void;
+}
+
+const Button = ({ children, onClick }: ButtonProps) => {
+  return (
+    <button className={styles.primary} onClick={onClick}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,11 +1,11 @@
 import styles from "../styles/Button.module.css";
 
-interface ButtonProps {
+interface Props {
   children: string;
   onClick: () => void;
 }
 
-const Button = ({ children, onClick }: ButtonProps) => {
+const Button = ({ children, onClick }: Props) => {
   return (
     <button className={styles.primary} onClick={onClick}>
       {children}

--- a/src/components/Motivational.tsx
+++ b/src/components/Motivational.tsx
@@ -1,14 +1,14 @@
 import Button from "./Button";
 import ViewState, { ChangeViewState } from '../ViewState';
 
-interface StartProps {
-  onStartClick: (newState: ChangeViewState) => void;
+interface Props {
+  onMotivationalClick: (newState: ChangeViewState) => void;
 }
 
-const Start = (startProps: StartProps) => {
+const Motivational = (props: Props) => {
 
   const clickHandler = () => {
-    startProps.onStartClick({to: ViewState.Routines});
+    props.onMotivationalClick({to: ViewState.Routines});
   };
 
   return (
@@ -26,4 +26,4 @@ const Start = (startProps: StartProps) => {
   );
 };
 
-export default Start;
+export default Motivational;

--- a/src/components/Routine.tsx
+++ b/src/components/Routine.tsx
@@ -1,10 +1,10 @@
 import Button from './Button';
 
-interface RoutineProps {
+interface Props {
   name: string;
 }
 
-const Routine = (props: RoutineProps) => {
+const Routine = (props: Props) => {
   return (
     <div>
       <h1>{props.name}</h1>

--- a/src/components/Routine.tsx
+++ b/src/components/Routine.tsx
@@ -1,0 +1,17 @@
+import Button from './Button';
+
+interface RoutineProps {
+  name: string;
+}
+
+const Routine = (props: RoutineProps) => {
+  return (
+    <div>
+      <h1>{props.name}</h1>
+      <Button onClick={()=> {}}>Start</Button>
+      <Button onClick={()=> {}}>End</Button>
+    </div>
+  );
+};
+
+export default Routine;

--- a/src/components/Routines.tsx
+++ b/src/components/Routines.tsx
@@ -1,8 +1,17 @@
+import ViewState, { ChangeViewState } from "../ViewState";
 import Button from "./Button";
 
-const Routines = () => {
+interface RoutinesProps {
+  onBackClick: (newState: ChangeViewState) => void;
+}
+
+const Routines = (routinesProps: RoutinesProps) => {
   const handleOnClick = () => {
     console.log("Clicked!");
+  };
+
+  const handleBackClick = () => {
+    routinesProps.onBackClick({ to: ViewState.Home });
   };
 
   return (
@@ -11,6 +20,7 @@ const Routines = () => {
       <Button onClick={handleOnClick}>Fitness</Button>
       <Button onClick={handleOnClick}>Eisbaden</Button>
       <Button onClick={handleOnClick}>Yoga</Button>
+      <Button onClick={handleBackClick}>Back</Button>
     </div>
   );
 };

--- a/src/components/Routines.tsx
+++ b/src/components/Routines.tsx
@@ -1,0 +1,18 @@
+import Button from "./Button";
+
+const Routines = () => {
+  const handleOnClick = () => {
+    console.log("Clicked!");
+  };
+
+  return (
+    <div>
+      <h1>Routines</h1>
+      <Button onClick={handleOnClick}>Fitness</Button>
+      <Button onClick={handleOnClick}>Eisbaden</Button>
+      <Button onClick={handleOnClick}>Yoga</Button>
+    </div>
+  );
+};
+
+export default Routines;

--- a/src/components/Routines.tsx
+++ b/src/components/Routines.tsx
@@ -1,7 +1,9 @@
 import ViewState, { ChangeViewState } from "../ViewState";
 import Button from "./Button";
 
+
 interface RoutinesProps {
+  routines: string[];
   onBackClick: (newState: ChangeViewState) => void;
 }
 
@@ -17,9 +19,9 @@ const Routines = (routinesProps: RoutinesProps) => {
   return (
     <div>
       <h1>Routines</h1>
-      <Button onClick={handleOnClick}>Fitness</Button>
-      <Button onClick={handleOnClick}>Eisbaden</Button>
-      <Button onClick={handleOnClick}>Yoga</Button>
+        {routinesProps.routines.map((routine, index) => {
+          return <Button key={index} onClick={handleOnClick}>{routine}</Button>;
+        })}
       <Button onClick={handleBackClick}>Back</Button>
     </div>
   );

--- a/src/components/Routines.tsx
+++ b/src/components/Routines.tsx
@@ -5,11 +5,13 @@ import Button from "./Button";
 interface RoutinesProps {
   routines: string[];
   onBackClick: (newState: ChangeViewState) => void;
+  onShowRoutineClick: (newState: ChangeViewState) => void;
 }
 
 const Routines = (routinesProps: RoutinesProps) => {
-  const handleOnClick = () => {
-    console.log("Clicked!");
+  const handleOnClick = (name: string) => {
+    console.log("Handled: " + name)
+    routinesProps.onShowRoutineClick({ to: ViewState.Routine, name: name });
   };
 
   const handleBackClick = () => {
@@ -20,7 +22,7 @@ const Routines = (routinesProps: RoutinesProps) => {
     <div>
       <h1>Routines</h1>
         {routinesProps.routines.map((routine, index) => {
-          return <Button key={index} onClick={handleOnClick}>{routine}</Button>;
+          return <Button key={index} onClick={() => {handleOnClick(routine)}}>{routine}</Button>;
         })}
       <Button onClick={handleBackClick}>Back</Button>
     </div>

--- a/src/components/Routines.tsx
+++ b/src/components/Routines.tsx
@@ -2,13 +2,13 @@ import ViewState, { ChangeViewState } from "../ViewState";
 import Button from "./Button";
 
 
-interface RoutinesProps {
+interface Props {
   routines: string[];
   onBackClick: (newState: ChangeViewState) => void;
   onShowRoutineClick: (newState: ChangeViewState) => void;
 }
 
-const Routines = (routinesProps: RoutinesProps) => {
+const Routines = (routinesProps: Props) => {
   const handleOnClick = (name: string) => {
     console.log("Handled: " + name)
     routinesProps.onShowRoutineClick({ to: ViewState.Routine, name: name });

--- a/src/components/Start.tsx
+++ b/src/components/Start.tsx
@@ -1,0 +1,27 @@
+import Button from "./Button";
+interface StartProps {
+  onButtonClick: () => void;
+  onStartClick: () => void;
+}
+
+const Start = (onButtonClick: StartProps) => {
+  const handleStartClick = () => {
+    console.log("Click event reached Start");
+  };
+
+  return (
+    <div>
+      <h1>Routines</h1>
+      <p>
+        Embracing routines empowers you to craft a path towards success,
+        enabling consistent progress, building discipline, and unlocking your
+        fullest potential every single day.
+      </p>
+      <Button onButtonClick={onButtonClick} onStartClick={handleStartClick}>
+        Let's go!
+      </Button>
+    </div>
+  );
+};
+
+export default Start;

--- a/src/components/Start.tsx
+++ b/src/components/Start.tsx
@@ -1,12 +1,14 @@
 import Button from "./Button";
+import ViewState, { ChangeViewState } from '../ViewState';
+
 interface StartProps {
-  onButtonClick: () => void;
-  onStartClick: () => void;
+  onStartClick: (newState: ChangeViewState) => void;
 }
 
-const Start = (onButtonClick: StartProps) => {
-  const handleStartClick = () => {
-    console.log("Click event reached Start");
+const Start = (startProps: StartProps) => {
+
+  const clickHandler = () => {
+    startProps.onStartClick({to: ViewState.Routines});
   };
 
   return (
@@ -17,7 +19,7 @@ const Start = (onButtonClick: StartProps) => {
         enabling consistent progress, building discipline, and unlocking your
         fullest potential every single day.
       </p>
-      <Button onButtonClick={onButtonClick} onStartClick={handleStartClick}>
+      <Button onClick={clickHandler}>
         Let's go!
       </Button>
     </div>

--- a/src/data.json
+++ b/src/data.json
@@ -1,0 +1,7 @@
+{
+  "routines": [
+    "Fitness",
+    "Eisbaden",
+    "Yoga"
+  ]
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,14 +3,6 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 a {
@@ -30,39 +22,3 @@ body {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}

--- a/src/styles/Button.module.css
+++ b/src/styles/Button.module.css
@@ -1,0 +1,15 @@
+.primary {
+  border-radius: 4px;
+  background: #FFB800; 
+  border: none;
+  border-bottom: 4px solid #DEA718;
+  width: 100%;
+  padding: 15px 10px;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.primary:hover {
+  margin-top: 4px;
+  border-bottom: none;
+}

--- a/src/styles/Button.module.css
+++ b/src/styles/Button.module.css
@@ -1,13 +1,21 @@
 .primary {
   border-radius: 4px;
-  background: #FFB800; 
+  background: #FFB800;
   border: none;
   border-bottom: 4px solid #DEA718;
-  width: 100%;
+  width: 80%;
   padding: 15px 10px;
   font-size: 20px;
   cursor: pointer;
+  margin-bottom: 15px;
 }
+
+@media only screen and (max-width: 375px) {
+  .primary {
+    width: 100%;
+  }
+}
+
 
 .primary:hover {
   margin-top: 4px;


### PR DESCRIPTION
This example demonstrates how you can change views without the use of a router.

The main logic for this sits in `App.tsx`. It mounts all main views, such as `Home` or `Routines`.
It also keeps state of the current view (`currentView`). I chose an enum for this job but this could also just be an integer. 

The main logic sits here, where we decide what to render:
```jsx
{currentView === ViewState.Home ? <Start onStartClick={handleOnClick} /> : null}
{currentView === ViewState.Routines ? <Routines /> : null}
```

We also provide the click handler to the components. I only passed it to `Start` for demonstration purposes but this would also be passed to `Routines` later on.

`Start` has its own internal click handler that wraps the handler it received via props. The reason for that is so that it can invoke the `onStartClick` handler with the correct parameters. 
